### PR TITLE
Change Direct Installation Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ sudo mv git-generate-license /usr/local/bin/
 Just copy and paste this one-line command:
 
 ```bash
-$ bash -c  "$(wget -qO- https://git.io/fj2J9)" 
+$ bash -c  "$(wget -qO- https://raw.githubusercontent.com/foss-dev/git-license-generator/master/install)" 
 ```
 
 Or, if you are a Mac user:
 
 ```bash
-$ bash -c  "$(curl -sLo- https://git.io/fj2J9)"
+$ bash -c  "$(curl -sLo- https://raw.githubusercontent.com/foss-dev/git-license-generator/master/install)"
 ```
 
 ## Usage


### PR DESCRIPTION
Changed the direct installation command links from git.io shortner to the full link path, to make it clear to users what the commands are going to do.